### PR TITLE
Support multi-value query params

### DIFF
--- a/iamauth/sigv4.py
+++ b/iamauth/sigv4.py
@@ -36,7 +36,7 @@ class Sigv4Auth(AuthBase):
             method=request.method,
             url=f"{url.scheme}://{url.netloc}{url.path}",
             data=request.body,
-            params=dict(parse_qsl(url.query)),
+            params=parse_qsl(url.query),
         )
 
         # Sign request

--- a/iamauth/sigv4a.py
+++ b/iamauth/sigv4a.py
@@ -42,7 +42,7 @@ class Sigv4aAuth(AuthBase):
         # Prepare AWS request
         aws_url = f"{url.scheme}://{url.netloc}{url.path}"
         aws_headers = dict(request.headers)
-        aws_params = dict(parse_qsl(url.query))
+        aws_params = parse_qsl(url.query)
         aws_request = AWSRequest(
             method=request.method,
             url=aws_url,

--- a/tests/test_sigv4.py
+++ b/tests/test_sigv4.py
@@ -1,3 +1,5 @@
+from urllib.parse import urlparse, parse_qsl
+
 import boto3
 import requests
 
@@ -23,3 +25,18 @@ class TestSigv4Auth:
         prq = req.prepare()
         assert "X-Amz-Date" in prq.headers
         assert "Authorization" in prq.headers
+
+    def test_call_with_query_params(self):
+        req = requests.Request(
+            "GET",
+            "http://example.com/",
+            auth=self.subject,
+            params={"singleValueParam": "val1", "multiValueParam": ["val2", "val3"]},
+        )
+        prq = req.prepare()
+        query = urlparse(prq.url).query
+        assert parse_qsl(query) == [
+            ("singleValueParam", "val1"),
+            ("multiValueParam", "val2"),
+            ("multiValueParam", "val3"),
+        ]

--- a/tests/test_sigv4a.py
+++ b/tests/test_sigv4a.py
@@ -1,3 +1,5 @@
+from urllib.parse import urlparse, parse_qsl
+
 import requests
 from botocore.compat import awscrt
 
@@ -23,3 +25,18 @@ class TestIAMAuth:
         prq = req.prepare()
         assert "X-Amz-Date" in prq.headers
         assert "Authorization" in prq.headers
+
+    def test_call_with_query_params(self):
+        req = requests.Request(
+            "GET",
+            "http://example.com/",
+            auth=self.subject,
+            params={"singleValueParam": "val1", "multiValueParam": ["val2", "val3"]},
+        )
+        prq = req.prepare()
+        query = urlparse(prq.url).query
+        assert parse_qsl(query) == [
+            ("singleValueParam", "val1"),
+            ("multiValueParam", "val2"),
+            ("multiValueParam", "val3"),
+        ]


### PR DESCRIPTION
We have a use case that needs multi-value query params and we noticed that the authorizer discards all but the last query params with the same key.

This PR removes this restriction by omitting the `dict` conversion and directly passes the result of `urllib.parse.parse_qsl`. This change is safe to use because `SigV4Auth.add_auth` internally converts to this format anyway as can be seen [here](https://github.com/boto/botocore/blob/develop/botocore/auth.py#L264-L271). 
